### PR TITLE
fix: undefined constant - spelling mistake

### DIFF
--- a/src/Room.php
+++ b/src/Room.php
@@ -868,7 +868,7 @@ class Room {
                         if ($econtent['membership'] == 'join') {
                             $userId = $stateEvent['state_key'];
                             $this->addMember($userId, array_get($econtent, 'displayname'));
-                        } elseif (in_array(econtent["membership"], ["leave", "kick", "invite"])) {
+                        } elseif (in_array($econtent["membership"], ["leave", "kick", "invite"])) {
                             unset($this->_members[array_get($stateEvent, 'state_key')]);
                         }
                     }


### PR DESCRIPTION
## Description

Changes the constant econtent to a variable, as econtent was not defined as constant before.

`Error {#321
  #message: "Undefined constant "MatrixPhp\econtent""
  #code: 0
  #file: "E:\WebProjects\ticket-system\vendor\meet-kinksters\php-matrix-sdk\src\Room.php"
  #line: 871
  trace: {
    E:\WebProjects\ticket-system\vendor\meet-kinksters\php-matrix-sdk\src\Room.php:871 { …}
    E:\WebProjects\ticket-system\vendor\meet-kinksters\php-matrix-sdk\src\MatrixClient.php:523 { …}
    E:\WebProjects\ticket-system\vendor\meet-kinksters\php-matrix-sdk\src\MatrixClient.php:242 { …}
    E:\WebProjects\ticket-system\vendor\meet-kinksters\php-matrix-sdk\src\MatrixClient.php:188 { …}
      App\Service\MatrixTicketService->__construct(string $url, string $username, string $password, string $room)^
      › $this->client = new MatrixClient($url);
      › $this->room = $this->client->joinRoom($room);
      arguments: {
        $username: "xxxx"
        $password: "xxxxx"
      }
    }
    E:\WebProjects\ticket-system\var\cache\dev\ContainerXm7s98f\getTicketServiceService.php:23 { …}
    E:\WebProjects\ticket-system\var\cache\dev\ContainerXm7s98f\App_KernelDevDebugContainer.php:600 { …}
    E:\WebProjects\ticket-system\vendor\symfony\dependency-injection\Container.php:422 { …}
    E:\WebProjects\ticket-system\vendor\symfony\dependency-injection\Argument\ServiceLocator.php:42 { …}
    E:\WebProjects\ticket-system\vendor\symfony\console\CommandLoader\ContainerCommandLoader.php:45 { …}
    E:\WebProjects\ticket-system\vendor\symfony\console\Application.php:596 { …}
    E:\WebProjects\ticket-system\vendor\symfony\console\Application.php:685 { …}
    E:\WebProjects\ticket-system\vendor\symfony\framework-bundle\Console\Application.php:116 { …}
    E:\WebProjects\ticket-system\vendor\symfony\console\Application.php:259 { …}
    E:\WebProjects\ticket-system\vendor\symfony\framework-bundle\Console\Application.php:82 { …}
  }
}`

## Motivation and context

This issues resolves a problem when joining a room, which the user is already member of - This fixes the issue #1 

## How has this been tested?

Tested if error is throwing up again, it did not. Message was sent successfully

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

As this was a syntax-mistake I expect to not add a test for it.
