### PR TITLE
fix error: change const econtent to array variable $econtent

### DIFF
--- a/src/Room.php
+++ b/src/Room.php
@@ -868,7 +868,7 @@ class Room {
                         if ($econtent['membership'] == 'join') {
                             $userId = $stateEvent['state_key'];
                             $this->addMember($userId, array_get($econtent, 'displayname'));
-                        } elseif (in_array(econtent["membership"], ["leave", "kick", "invite"])) {
+                        } elseif (in_array($econtent["membership"], ["leave", "kick", "invite"])) {
                             unset($this->_members[array_get($stateEvent, 'state_key')]);
                         }
                     }


### PR DESCRIPTION
the const  econtent (it's a typo, I think) throws a Fatal error in Php 8.1